### PR TITLE
Add support for simple trip query with optional destination ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,9 @@ sensor:
         stop_id: 33000112 # actual Stop ID for the API
       - name: "Altmarkt" # you can add more that one stop to track
         stop_id: 33000004
-        
+      - name: "Hauptbahnhof --> Nürnberger Platz" # Only show Departures in that direction
+        stop_id: 33000028
+        destination_id: 33000132 # you can add a destination ID (using the same approach as for the stop ID) to show only usable departures for that direction/trip 
         # Optional parameter with value in minutes that hide transport closer than N minutes
         # walking_time: 5
 ```

--- a/custom_components/dresden_transport/const.py
+++ b/custom_components/dresden_transport/const.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 DOMAIN = "dresden_transport"
 SCAN_INTERVAL = timedelta(seconds=90)
 API_ENDPOINT = "https://webapi.vvo-online.de/dm"
+API_ENDPOINT_TRIP = "https://webapi.vvo-online.de/tr/trips?format=json"
 API_MAX_RESULTS = 10
 
 DEFAULT_ICON = "mdi:clock"
@@ -13,6 +14,7 @@ CONF_DEPARTURES_NAME = "name"
 CONF_DEPARTURES_STOP_ID = "stop_id"
 CONF_DEPARTURES_WALKING_TIME = "walking_time"
 CONF_DEPARTURES_DIRECTION = "direction"
+CONF_DEPARTURES_DESTINATION_ID = "destination_id"
 CONF_TYPE_SUBURBAN = "suburban"
 CONF_TYPE_SUBWAY = "subway"
 CONF_TYPE_TRAM = "Tram"

--- a/custom_components/dresden_transport/departure.py
+++ b/custom_components/dresden_transport/departure.py
@@ -38,7 +38,34 @@ class Departure:
             bg_color=source.get("line", {}).get("color", {}).get("bg"),
             fallback_color=line_visuals.get("color"),
         )
-
+    @classmethod
+    def from_dict_dir(cls, source):
+        line_type = source.get("MotChain", [])[0].get("Type")
+        line_visuals = TRANSPORT_TYPE_VISUALS.get(line_type) or {}
+        time_str = source.get("PartialRoutes",[])[0].get("RegularStops",[])[0].get("DepartureTime")
+        line_name = source.get("MotChain", [])[0].get("Name")
+        line_type = source.get("MotChain", [])[0].get("Type")
+        direction = source.get("MotChain", [])[0].get("Direction")
+        platform = source.get("PartialRoutes", [])[0].get("RegularStops", [])[0].get("Platform", {}).get("Name")
+        bg_color = source.get("line", {}).get("color", {}).get("bg")
+        fallback_color = line_visuals.get("color")
+        
+        res = re.search(r'\d+', time_str) 
+        time = int(int(res.group()) / 1000)
+        gap = round((datetime.fromtimestamp(time) - datetime.now()).total_seconds() / 60)
+        return cls(
+            line_name=line_name,
+            line_type=line_type,
+            gap=gap,
+            timestamp=time,
+            time=datetime.fromtimestamp(time).strftime("%H:%M"),
+            direction=direction,
+            platform=platform,
+            icon=line_visuals.get("icon") or DEFAULT_ICON,
+            bg_color=bg_color,
+            fallback_color=fallback_color,
+        )
+        
     def to_dict(self):
         return {
             "line_name": self.line_name,


### PR DESCRIPTION
This pull request implements a new feature to enhance the Trip Query functionality by allowing an optional `destination_id` parameter. This parameter filters departures to only show those heading towards the specified destination. The following changes and improvements have been made:

## Changes:

- Added support for `destination_id` using new `API_ENDPOINT_TRIP` and `CONF_DEPARTURES_DESTINATION_ID`
- Added function `fetch_departures_directional` and `from_dict_dir` for changed API request format of trip query

## Improvements Needed/Future Work:
- Additional Information: Implement displaying additional trip information such as the duration of the trip, number of transfers, etc.
- Currently, only direct trips and the first stop are shown. The destination_id acts primarily as a filter to ignore unnecessary departures.
- only the next 3 departures are queried